### PR TITLE
DIA-4609 post custom consent call

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
@@ -28,6 +28,7 @@ import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.SIMPLE
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -164,7 +165,7 @@ class SourcepointClient(
             setBody(request)}).bodyOr(::reportErrorAndThrow)
 
     override suspend fun deleteCustomConsentGDPR(request: CustomConsentRequest): GDPRConsent =
-        http.post(URLBuilder(baseWrapperUrl).apply {
+        http.delete(URLBuilder(baseWrapperUrl).apply {
             path("consent", "tcfv2", "consent", "v3", "custom")
             appendPathSegments(request.propertyId.toString())
             withParams(mapOf("consentUUID" to request.consentUUID))

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
@@ -33,7 +33,10 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
+import io.ktor.http.ContentType
 import io.ktor.http.URLBuilder
+import io.ktor.http.appendPathSegments
+import io.ktor.http.contentType
 import io.ktor.http.path
 import io.ktor.serialization.kotlinx.json.json
 import kotlin.reflect.KSuspendFunction1
@@ -155,14 +158,19 @@ class SourcepointClient(
     override suspend fun customConsentGDPR(request: CustomConsentRequest): GDPRConsent =
         http.post(URLBuilder(baseWrapperUrl).apply {
             path("wrapper", "tcfv2", "v1", "gdpr", "custom-consent")
-            withParams(DefaultRequest)
-        }.build(), block = {setBody(request)}).bodyOr(::reportErrorAndThrow)
+            withParams(DefaultRequest())
+        }.build(), block = {
+            contentType(ContentType.Application.Json)
+            setBody(request)}).bodyOr(::reportErrorAndThrow)
 
     override suspend fun deleteCustomConsentGDPR(request: CustomConsentRequest): GDPRConsent =
         http.post(URLBuilder(baseWrapperUrl).apply {
-            path("consent", "tcfv2", "consent", "v3", "custom", request.propertyId.toString())
-            withParams(request.consentUUID)
-        }.build(), block = {setBody(request)}).bodyOr(::reportErrorAndThrow)
+            path("consent", "tcfv2", "consent", "v3", "custom")
+            appendPathSegments(request.propertyId.toString())
+            withParams(mapOf("consentUUID" to request.consentUUID))
+        }.build(), block = {
+            contentType(ContentType.Application.Json)
+            setBody(request)}).bodyOr(::reportErrorAndThrow)
 
     override suspend fun errorMetrics(error: SPError) {
         http.post(URLBuilder(baseWrapperUrl).apply {

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
@@ -9,4 +9,4 @@ data class CustomConsentRequest (
     val vendors: List<String> = emptyList(),
     val categories: List<String> = emptyList(),
     val legIntCategories: List<String> = emptyList()
-): DefaultRequest()
+)

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
@@ -9,4 +9,4 @@ data class CustomConsentRequest (
     val vendors: List<String> = emptyList(),
     val categories: List<String> = emptyList(),
     val legIntCategories: List<String> = emptyList()
-): DefaultRequest() {}
+): DefaultRequest()

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
@@ -1,0 +1,12 @@
+package com.sourcepoint.mobile_core.network.requests
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CustomConsentRequest (
+    val consentUUID: String,
+    val propertyId: Int,
+    val vendors: List<String> = emptyList(),
+    val categories: List<String> = emptyList(),
+    val legIntCategories: List<String> = emptyList()
+): DefaultRequest() {}

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/CustomConsentRequest.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class CustomConsentRequest (
     val consentUUID: String,
     val propertyId: Int,
-    val vendors: List<String> = emptyList(),
-    val categories: List<String> = emptyList(),
-    val legIntCategories: List<String> = emptyList()
+    val vendors: List<String>,
+    val categories: List<String>,
+    val legIntCategories: List<String>
 )

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -246,5 +247,23 @@ class SourcepointClientTest {
         SourcepointClient(accountId, propertyId, propertyName, httpEngine = mockEngine)
             .deleteCustomConsentGDPR(CustomConsentRequest("uuid",propertyId, emptyList(), emptyList(), emptyList()))
         assertEquals(mockEngine.requestHistory.last().url, Url("https://cdn.privacy-mgmt.com/consent/tcfv2/consent/v3/custom/16893?consentUUID=uuid"))
+    }
+
+    @Test
+    fun checkCustomConsent() = runTest {
+        val vendors = listOf("5ff4d000a228633ac048be41")
+        val categories = listOf("608bad95d08d3112188e0e36", "608bad95d08d3112188e0e2f")
+        val responseCustom = SourcepointClient(accountId, propertyId, propertyName)
+            .customConsentGDPR(CustomConsentRequest("uuid_36",propertyId, vendors, categories, emptyList()))
+        val responseDeleteCustom = SourcepointClient(accountId, propertyId, propertyName)
+            .deleteCustomConsentGDPR(CustomConsentRequest("uuid_36",propertyId, vendors, categories, emptyList()))
+
+        assertTrue(responseCustom.vendors.contains(vendors.first()))
+        assertFalse(responseDeleteCustom.vendors.contains(vendors.first()))
+
+        assertTrue(responseCustom.categories.contains(categories.first()))
+        assertFalse(responseDeleteCustom.categories.contains(categories.first()))
+        assertTrue(responseCustom.categories.contains(categories.last()))
+        assertFalse(responseDeleteCustom.categories.contains(categories.last()))
     }
 }

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
@@ -237,30 +237,26 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun checkUrlBuilderCustomConsent() = runTest {
-        val mockEngine = mock()
-        SourcepointClient(accountId, propertyId, propertyName, httpEngine = mockEngine)
-            .customConsentGDPR(CustomConsentRequest("uuid",propertyId, emptyList(), emptyList(), emptyList()))
-        val defaultRequest = DefaultRequest()
-        assertEquals(mockEngine.requestHistory.last().url, Url("https://cdn.privacy-mgmt.com/wrapper/tcfv2/v1/gdpr/custom-consent?env="+defaultRequest.env+"&scriptType="+defaultRequest.scriptType+"&scriptVersion="+defaultRequest.scriptVersion))
-
-        SourcepointClient(accountId, propertyId, propertyName, httpEngine = mockEngine)
-            .deleteCustomConsentGDPR(CustomConsentRequest("uuid",propertyId, emptyList(), emptyList(), emptyList()))
-        assertEquals(mockEngine.requestHistory.last().url, Url("https://cdn.privacy-mgmt.com/consent/tcfv2/consent/v3/custom/16893?consentUUID=uuid"))
-    }
-
-    @Test
     fun checkCustomConsent() = runTest {
         val vendors = listOf("5ff4d000a228633ac048be41")
         val categories = listOf("608bad95d08d3112188e0e36", "608bad95d08d3112188e0e2f")
-        val responseCustom = SourcepointClient(accountId, propertyId, propertyName)
-            .customConsentGDPR(CustomConsentRequest("uuid_36",propertyId, vendors, categories, emptyList()))
-        val responseDeleteCustom = SourcepointClient(accountId, propertyId, propertyName)
-            .deleteCustomConsentGDPR(CustomConsentRequest("uuid_36",propertyId, vendors, categories, emptyList()))
+        val responseCustom = api.customConsentGDPR(
+            "uuid_36",
+            propertyId,
+            vendors,
+            categories,
+            emptyList()
+        )
+        val responseDeleteCustom = api.deleteCustomConsentGDPR(
+            "uuid_36",
+            propertyId,
+            vendors,
+            categories,
+            emptyList()
+        )
 
         assertTrue(responseCustom.vendors.contains(vendors.first()))
         assertFalse(responseDeleteCustom.vendors.contains(vendors.first()))
-
         assertTrue(responseCustom.categories.contains(categories.first()))
         assertFalse(responseDeleteCustom.categories.contains(categories.first()))
         assertTrue(responseCustom.categories.contains(categories.last()))

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
@@ -11,12 +11,15 @@ import com.sourcepoint.mobile_core.models.consents.CCPAConsent
 import com.sourcepoint.mobile_core.models.consents.ConsentStatus
 import com.sourcepoint.mobile_core.models.consents.GDPRConsent
 import com.sourcepoint.mobile_core.models.consents.USNatConsent
+import com.sourcepoint.mobile_core.network.requests.CustomConsentRequest
+import com.sourcepoint.mobile_core.network.requests.DefaultRequest
 import com.sourcepoint.mobile_core.network.responses.MessagesResponse
 import com.sourcepoint.mobile_core.network.requests.MessagesRequest
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.delay
@@ -230,5 +233,18 @@ class SourcepointClientTest {
 
         assertNotNull(mockEngine.requestHistory.firstOrNull { it.url.pathSegments.contains("meta-data") })
         assertNotNull(mockEngine.requestHistory.firstOrNull { it.url.pathSegments.contains("custom-metrics") })
+    }
+
+    @Test
+    fun checkUrlBuilderCustomConsent() = runTest {
+        val mockEngine = mock()
+        SourcepointClient(accountId, propertyId, propertyName, httpEngine = mockEngine)
+            .customConsentGDPR(CustomConsentRequest("uuid",propertyId, emptyList(), emptyList(), emptyList()))
+        val defaultRequest = DefaultRequest()
+        assertEquals(mockEngine.requestHistory.last().url, Url("https://cdn.privacy-mgmt.com/wrapper/tcfv2/v1/gdpr/custom-consent?env="+defaultRequest.env+"&scriptType="+defaultRequest.scriptType+"&scriptVersion="+defaultRequest.scriptVersion))
+
+        SourcepointClient(accountId, propertyId, propertyName, httpEngine = mockEngine)
+            .deleteCustomConsentGDPR(CustomConsentRequest("uuid",propertyId, emptyList(), emptyList(), emptyList()))
+        assertEquals(mockEngine.requestHistory.last().url, Url("https://cdn.privacy-mgmt.com/consent/tcfv2/consent/v3/custom/16893?consentUUID=uuid"))
     }
 }


### PR DESCRIPTION
[DIA-4609](https://sourcepoint.atlassian.net/browse/DIA-4609) Implement POST `/custom-consent` and DELETE `/custom-consent` calls.

[DIA-4609]: https://sourcepoint.atlassian.net/browse/DIA-4609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ