### PR TITLE
Fix ccpa consent status serializer always unknown

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/CCPAConsent.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/CCPAConsent.kt
@@ -1,6 +1,5 @@
 package com.sourcepoint.mobile_core.models.consents
 
-import com.sourcepoint.mobile_core.utils.StringEnumWithDefaultSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -14,18 +13,16 @@ data class CCPAConsent(
     var uspstring: String? = null,
     val rejectedVendors: List<String> = emptyList(),
     val rejectedCategories: List<String> = emptyList(),
-    val status: CCPAConsentStatus = CCPAConsentStatus.Unknown,
+    val status: CCPAConsentStatus? = null,
     val webConsentPayload: String? = null,
     @SerialName("GPPData") val gppData: IABData = emptyMap(),
 ) {
-    @Serializable(with = CCPAConsentStatus.Serializer::class)
+    @Serializable
     enum class CCPAConsentStatus {
         @SerialName("consentedAll") ConsentedAll,
         @SerialName("rejectedAll") RejectedAll,
         @SerialName("rejectedSome") RejectedSome,
         @SerialName("rejectedNone") RejectedNone,
-        @SerialName("linkedNoAction") LinkedNoAction,
-        Unknown;
-        object Serializer: StringEnumWithDefaultSerializer<CCPAConsentStatus>(entries, Unknown)
+        @SerialName("linkedNoAction") LinkedNoAction
     }
 }

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
@@ -138,7 +138,7 @@ class SourcepointClientTest {
         assertNotNull(consents)
         assertTrue(consents.gppData.isNotEmpty())
         assertNotNull(consents.signedLspa)
-        assertNotEquals(CCPAConsent.CCPAConsentStatus.Unknown, consents.status)
+        assertNotEquals(CCPAConsent.CCPAConsentStatus.RejectedNone, consents.status)
         assertTrue(consents.rejectedCategories.isNotEmpty())
         assertTrue(consents.rejectedVendors.isNotEmpty())
         assertTrue(consents.dateCreated!!.isNotEmpty())


### PR DESCRIPTION
The ccpa consent status was always being deserialized to `Unknown`. This PR addresses this issue by
usein kotlin serializer's default serializer for enums instead of custom made one.
