### PR TITLE
make enums serialization case insensitive

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/Json.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/Json.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 
 @OptIn(ExperimentalSerializationApi::class)
 val json = Json {
+    decodeEnumsCaseInsensitive = true
     encodeDefaults = true
     ignoreUnknownKeys = true
     explicitNulls = false
@@ -12,6 +13,7 @@ val json = Json {
 
 @OptIn(ExperimentalSerializationApi::class)
 val jsonWithNulls = Json {
+    decodeEnumsCaseInsensitive = true
     encodeDefaults = true
     ignoreUnknownKeys = true
     explicitNulls = true

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/DefaultEnumSerializerTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/DefaultEnumSerializerTest.kt
@@ -1,0 +1,26 @@
+package com.sourcepoint.mobile_core.utils
+
+import com.sourcepoint.mobile_core.network.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultEnumSerializerTest {
+    @Serializable
+    enum class MyEnum {
+        Foo,
+        @SerialName("BAR") Bar
+    }
+
+    @Test
+    fun serializingEnumsIsCaseInsensitive() = runTest {
+        assertEquals(MyEnum.Foo, json.decodeFromString("\"Foo\""))
+        assertEquals(MyEnum.Foo, json.decodeFromString("\"foo\""))
+
+        assertEquals(MyEnum.Bar, json.decodeFromString("\"Bar\""))
+        assertEquals(MyEnum.Bar, json.decodeFromString("\"BAR\""))
+        assertEquals(MyEnum.Bar, json.decodeFromString("\"bar\""))
+    }
+}

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/StringEnumWithDefaultSerializerTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/StringEnumWithDefaultSerializerTest.kt
@@ -7,19 +7,19 @@ import kotlinx.serialization.encodeToString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@Serializable(with = StringTestEnum.Serializer::class)
-enum class StringTestEnum {
-    Foo,
-    Bar,
-    Unknown;
-
-    object Serializer : StringEnumWithDefaultSerializer<StringTestEnum>(entries, Unknown)
-}
-
-@Serializable
-data class DummyWithStringEnum(val enumProperty: StringTestEnum)
-
 class StringEnumWithDefaultSerializerTest {
+    @Serializable(with = StringTestEnum.Serializer::class)
+    enum class StringTestEnum {
+        Foo,
+        Bar,
+        Unknown;
+
+        object Serializer : StringEnumWithDefaultSerializer<StringTestEnum>(entries, Unknown)
+    }
+
+    @Serializable
+    data class DummyWithStringEnum(val enumProperty: StringTestEnum)
+
     @Test
     fun encodeToString() = runTest {
         assertEquals("\"Foo\"", json.encodeToString(StringTestEnum.Foo))


### PR DESCRIPTION
This allows cases like message language "en" and "EN" being serialized to the correct enum value (EN).