### PR TITLE
add @Throws annotation to network calls

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
@@ -42,13 +42,13 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlin.reflect.KSuspendFunction1
 
 interface SPClient {
-    suspend fun getMetaData(campaigns: MetaDataRequest.Campaigns): MetaDataResponse
+    @Throws(Exception::class) suspend fun getMetaData(campaigns: MetaDataRequest.Campaigns): MetaDataResponse
 
-    suspend fun getConsentStatus(authId: String?, metadata: ConsentStatusRequest.MetaData): ConsentStatusResponse
+    @Throws(Exception::class) suspend fun getConsentStatus(authId: String?, metadata: ConsentStatusRequest.MetaData): ConsentStatusResponse
 
-    suspend fun getMessages(request: MessagesRequest): MessagesResponse
+    @Throws(Exception::class) suspend fun getMessages(request: MessagesRequest): MessagesResponse
 
-    suspend fun customConsentGDPR(
+    @Throws(Exception::class) suspend fun customConsentGDPR(
         consentUUID: String,
         propertyId: Int,
         vendors: List<String>,
@@ -56,7 +56,7 @@ interface SPClient {
         legIntCategories: List<String>
     ): GDPRConsent
 
-    suspend fun deleteCustomConsentGDPR(
+    @Throws(Exception::class) suspend fun deleteCustomConsentGDPR(
         consentUUID: String,
         propertyId: Int,
         vendors: List<String>,


### PR DESCRIPTION
Adding `@Throws` annotation to network calls allows us to handle network errors in the Swift and Android side. Without it, errors coming from the network will be terminal exceptions.