### PR TITLE
DIA-5097 add Basque to SPMessageLanguage

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPMessageLanguage.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPMessageLanguage.kt
@@ -3,6 +3,7 @@ package com.sourcepoint.mobile_core.models
 import kotlinx.serialization.SerialName
 
 enum class SPMessageLanguage(val shortCode: String) {
+   @SerialName("EUS") BASQUE("EUS"),
    @SerialName("BG") BULGARIAN("BG"),
    @SerialName("CA") CATALAN("CA"),
    @SerialName("ZH") CHINESE("ZH"),


### PR DESCRIPTION
_Do not merge, still confirming which language code to use: `eus` or `baq`_

Add support to Basque language.