### PR TITLE
DIA-5148 data migration / State refactoring

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -56,7 +56,7 @@ class Coordinator(
 
     private val needsNewConsentData: Boolean get() =
                 needsNewUSNatData || transitionCCPAOptedOut ||
-                (state.localVersion != State.version &&
+                (state.localVersion != State.VERSION &&
                         (state.gdpr?.uuid != null || state.ccpa?.uuid != null || state.usNat?.uuid != null))
 
     private val authTransitionCCPAUSNat: Boolean get() = (authId != null && campaigns.usnat?.transitionCCPAAuth == true)
@@ -320,13 +320,13 @@ class Coordinator(
         if (shouldCallConsentStatus) {
             try {
                 val response = spClient.getConsentStatus(authId = authId, metadata = consentStatusParamsFromState())
-                state.localVersion = State.version
+                state.localVersion = State.VERSION
                 handleConsentStatusResponse(response)
             } catch (error: Throwable) {
                 throw error
             }
         } else {
-            state.localVersion = State.version
+            state.localVersion = State.VERSION
         }
         next()
     }
@@ -376,7 +376,7 @@ class Coordinator(
             nonKeyedLocalState = state.nonKeyedLocalState,
             localState = state.localState
         )
-    
+
     private fun handleMessagesResponse(response: MessagesResponse): List<MessageToDisplay> {
         state.localState = response.localState
         state.nonKeyedLocalState = response.nonKeyedLocalState
@@ -820,4 +820,3 @@ class Coordinator(
     }
     //endregion
 }
-

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPCampaign.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPCampaign.kt
@@ -3,9 +3,9 @@ package com.sourcepoint.mobile_core.models
 import com.sourcepoint.mobile_core.network.requests.IncludeData
 
 data class SPCampaign (
-    val targetingParams: SPTargetingParams,
-    val groupPmId: String?,
-    val gppConfig: IncludeData.GPPConfig?,
-    val transitionCCPAAuth: Boolean?,
-    val supportLegacyUSPString: Boolean?
+    val targetingParams: SPTargetingParams = emptyMap(),
+    val groupPmId: String? = null,
+    val gppConfig: IncludeData.GPPConfig? = null,
+    val transitionCCPAAuth: Boolean? = null,
+    val supportLegacyUSPString: Boolean? = null
 )

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPCampaigns.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPCampaigns.kt
@@ -1,9 +1,9 @@
 package com.sourcepoint.mobile_core.models
 
 data class SPCampaigns (
-    val environment: SPCampaignEnv,
-    val gdpr: SPCampaign?,
-    val ccpa: SPCampaign?,
-    val usnat: SPCampaign?,
-    val ios14: SPCampaign?
+    val environment: SPCampaignEnv = SPCampaignEnv.PUBLIC,
+    val gdpr: SPCampaign? = null,
+    val ccpa: SPCampaign? = null,
+    val usnat: SPCampaign? = null,
+    val ios14: SPCampaign? = null
 )

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/State.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/State.kt
@@ -16,7 +16,7 @@ data class State (
     var nonKeyedLocalState: SPJson? = null
 ) {
     companion object {
-        const val version = 4
+        const val VERSION = 4
     }
 
     var storedAuthId: String? = null

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/storage/Repository.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/storage/Repository.kt
@@ -3,9 +3,7 @@ package com.sourcepoint.mobile_core.storage
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.get
 import com.russhwolf.settings.set
-import com.sourcepoint.mobile_core.models.SPJson
 import com.sourcepoint.mobile_core.models.consents.IABData
-import com.sourcepoint.mobile_core.models.consents.SPUserData
 import com.sourcepoint.mobile_core.models.consents.State
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
@@ -27,21 +25,6 @@ class Repository(private val storage: Settings) {
     var cachedGppData: IABData?
         get() = Json.decodeFromString<IABData>(storage[Keys.GppData.name, ":"])
         set(value) { if (value != null) storage[Keys.GppData.name] = Json.encodeToString(MapSerializer(String.serializer(),JsonPrimitive.serializer()), value) }
-    var cachedUspString: String?
-        get() = storage[Keys.UspString.name, ""]
-        set(value) { storage[Keys.UspString.name] = value }
-    var cachedUserData: SPUserData?
-        get() = try { Json.decodeFromString<SPUserData>(storage[Keys.UserData.name, ""]) } catch (error: Throwable) { null }
-        set(value) { storage[Keys.UserData.name] = Json.encodeToString(value) }
-    var cachedLocalState: SPJson?
-        get() = storage[Keys.LocalState.name, ""]
-        set(value) { storage[Keys.LocalState.name] = value }
-    var cachedGdprChildPmId: String?
-        get() = storage[Keys.GdprChildPmId.name, ""]
-        set(value) { storage[Keys.GdprChildPmId.name] = value }
-    var cachedCcpaChildPmId: String?
-        get() = storage[Keys.CcpaChildPmId.name, ""]
-        set(value) { storage[Keys.CcpaChildPmId.name] = value }
     var cachedSPState: State?
         get() = try { Json.decodeFromString<State>(storage[Keys.SPState.name, ""]) } catch (error: Throwable) { null }
         set(value) { storage[Keys.SPState.name] = Json.encodeToString(value) }

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/storage/Repository.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/storage/Repository.kt
@@ -18,11 +18,6 @@ class Repository(private val storage: Settings) {
     enum class Keys {
         TcData,
         GppData,
-        UspString,
-        UserData,
-        LocalState,
-        GdprChildPmId,
-        CcpaChildPmId,
         SPState
     }
 

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -40,11 +40,6 @@ class CoordinatorTest {
     }
 
     @Test
-    fun testConstructor() = runTest {
-        assertEquals(1, 1)
-    }
-
-    @Test
     fun reportActionReturnsGDPRConsent() = runTest {
         val saveAndExitAction = SPAction(
             type = SPActionType.AcceptAll,

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -3,47 +3,45 @@ package com.sourcepoint.mobile_core
 import com.russhwolf.settings.MapSettings
 import com.sourcepoint.mobile_core.models.SPAction
 import com.sourcepoint.mobile_core.models.SPActionType
+import com.sourcepoint.mobile_core.models.SPCampaign
 import com.sourcepoint.mobile_core.models.SPCampaignType
-import com.sourcepoint.mobile_core.models.consents.AttCampaign
-import com.sourcepoint.mobile_core.models.consents.CCPAConsent
-import com.sourcepoint.mobile_core.models.consents.GDPRConsent
+import com.sourcepoint.mobile_core.models.SPCampaigns
 import com.sourcepoint.mobile_core.models.consents.State
-import com.sourcepoint.mobile_core.models.consents.USNatConsent
+import com.sourcepoint.mobile_core.network.SourcepointClient
 import com.sourcepoint.mobile_core.network.requests.ChoiceAllRequest
-import com.sourcepoint.mobile_core.network.requests.MetaDataRequest
 import com.sourcepoint.mobile_core.storage.Repository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class CoordinatorTest {
     val storage = MapSettings()
     val repository = Repository(storage)
-    val coordinator = Coordinator(accountId = 22, propertyId = 16893, propertyName = "https://mobile.multicampaign.demo",  repository)
-
-    @Test
-    fun metaDataIsCached() = runTest {
-        val campaigns = MetaDataRequest.Campaigns(gdpr = MetaDataRequest.Campaigns.Campaign())
-        val metaData = coordinator.getMetaData(campaigns)
-        assertContains(metaData, "/meta-data")
-        assertContains(storage.keys, "MetaData")
-    }
+    lateinit var coordinator: Coordinator
 
     @BeforeTest
     fun initCoordinatorState(){
-        coordinator.state = State(
-            gdpr = GDPRConsent(),
-            ccpa = CCPAConsent(),
-            usNat = USNatConsent(),
-            ios14 = AttCampaign(),
-            gdprMetaData = null,
-            ccpaMetaData = null,
-            usNatMetaData = null,
-            localState = null,
-            nonKeyedLocalState = null
+        coordinator = Coordinator(
+            accountId = 22,
+            propertyId = 16893,
+            propertyName = "https://mobile.multicampaign.demo",
+            campaigns = SPCampaigns(
+                gdpr = SPCampaign(),
+                ccpa = SPCampaign(),
+                usnat = SPCampaign(),
+                ios14 = SPCampaign(),
+            ),
+            spClient = SourcepointClient(accountId = 22, propertyId = 16893, propertyName = "https://mobile.multicampaign.demo"),
+            repository = repository,
+            state = State()
         )
+    }
+
+    @Test
+    fun testConstructor() = runTest {
+        assertEquals(1, 1)
     }
 
     @Test
@@ -67,7 +65,7 @@ class CoordinatorTest {
             usnat = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(false),
             ccpa = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(false)
         ))
-        assertFalse(state.gdpr?.uuid.isNullOrEmpty())
+        assertFalse(state.gdpr.consents.uuid.isNullOrEmpty())
     }
 
     @Test
@@ -89,7 +87,7 @@ class CoordinatorTest {
             gdpr = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(false),
             usnat = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(false)
         ))
-        assertFalse(state.ccpa?.uuid.isNullOrEmpty())
+        assertFalse(state.ccpa.consents.uuid.isNullOrEmpty())
     }
 
     @Test
@@ -112,6 +110,6 @@ class CoordinatorTest {
             gdpr = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(false),
             ccpa = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(false)
         ))
-        assertFalse(state.usNat?.uuid.isNullOrEmpty())
+        assertFalse(state.usNat.consents.uuid.isNullOrEmpty())
     }
 }


### PR DESCRIPTION
### Refactor `State` from (pseudo code):
```
{
  legislation: LegislationConsent
  legislationMetaData: LegislationMetaData
}
```
to
```
{
   legislation: {
     consents: LegislationConsent,
     metaData: LegislationMetaData,
     childPmId: String?,
     ...
   }
}
```
### Refactor `State` to receive initial value

### Refactor `State` to remove `setupState` from `Coordinator`

### Refactor null checks to use `?.let{}` construct

⚠️ iOS tests are failing, need to fix that before merging
