### PR TITLE
Refactor `reportAction` signature

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -731,9 +731,16 @@ class Coordinator(
             throw error
         }
 
-    override suspend fun reportAction(action: SPAction, campaigns: ChoiceAllRequest.ChoiceAllCampaigns): SPUserData {
+    override suspend fun reportAction(action: SPAction): SPUserData {
         try {
-            val getResponse = getChoiceAll(action = action, campaigns = campaigns)
+            val getResponse = getChoiceAll(
+                action = action,
+                campaigns = ChoiceAllRequest.ChoiceAllCampaigns(
+                    gdpr = if (action.campaignType == SPCampaignType.Gdpr) ChoiceAllRequest.ChoiceAllCampaigns.Campaign(applies = state.gdpr.consents.applies) else null,
+                    ccpa = if (action.campaignType == SPCampaignType.Ccpa) ChoiceAllRequest.ChoiceAllCampaigns.Campaign(applies = state.ccpa.consents.applies) else null,
+                    usnat = if (action.campaignType == SPCampaignType.UsNat) ChoiceAllRequest.ChoiceAllCampaigns.Campaign(applies = state.usNat.consents.applies) else null
+                )
+            )
             when (action.campaignType) {
                 SPCampaignType.Gdpr -> reportGDPRAction(action = action, getResponse = getResponse)
                 SPCampaignType.Ccpa -> reportCCPAAction(action = action, getResponse = getResponse)

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/ICoordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/ICoordinator.kt
@@ -9,10 +9,8 @@ import kotlinx.serialization.json.JsonObject
 interface ICoordinator {
     val userData: SPUserData
 
-    @Throws(Exception::class) suspend fun reportAction(
-        action: SPAction,
-        campaigns: ChoiceAllRequest.ChoiceAllCampaigns
-    ): SPUserData
+    @Throws(Exception::class) suspend fun reportAction(action: SPAction): SPUserData
+
     @Throws(Exception::class) suspend fun loadMessages(
         authId: String?,
         pubData: JsonObject?

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -9,7 +9,6 @@ import com.sourcepoint.mobile_core.models.SPCampaigns
 import com.sourcepoint.mobile_core.models.consents.State
 import com.sourcepoint.mobile_core.network.SourcepointClient
 import com.sourcepoint.mobile_core.network.encodeToJsonObject
-import com.sourcepoint.mobile_core.network.requests.ChoiceAllRequest
 import com.sourcepoint.mobile_core.storage.Repository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -43,9 +42,6 @@ class CoordinatorTest {
     fun reportActionReturnsGDPRConsent() = runTest {
         val consents = coordinator.reportAction(
             action = SPAction(type = SPActionType.AcceptAll, campaignType = SPCampaignType.Gdpr),
-            campaigns = ChoiceAllRequest.ChoiceAllCampaigns(
-                gdpr = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(true)
-            )
         )
         assertFalse(consents.gdpr?.consents?.uuid.isNullOrEmpty())
     }
@@ -54,9 +50,6 @@ class CoordinatorTest {
     fun reportActionReturnsCCPAConsent() = runTest {
         val consents = coordinator.reportAction(
             action = SPAction(type = SPActionType.RejectAll, campaignType = SPCampaignType.Ccpa),
-            campaigns = ChoiceAllRequest.ChoiceAllCampaigns(
-                ccpa = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(true)
-            )
         )
         assertFalse(consents.ccpa?.consents?.uuid.isNullOrEmpty())
     }
@@ -76,9 +69,6 @@ class CoordinatorTest {
                     "vendors": []
                 }
                 """.encodeToJsonObject(),
-            ),
-            campaigns = ChoiceAllRequest.ChoiceAllCampaigns(
-                usnat = ChoiceAllRequest.ChoiceAllCampaigns.Campaign(true)
             )
         )
         assertFalse(consents.usnat?.consents?.uuid.isNullOrEmpty())


### PR DESCRIPTION
### Move from:
```
@Throws(Exception::class) suspend fun reportAction(action: SPAction, campaigns: ChoiceAllRequest.ChoiceAllCampaigns): SPUserData
```
to:
```
@Throws(Exception::class) suspend fun reportAction(action: SPAction): SPUserData
```

### Add `SPUserData` to `customConsent` and `deleteCustomConsent` functions