### PR TITLE
Reset State if property/account id changes and other refactorings

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("native.cocoapods") version "2.0.21"
     kotlin("plugin.serialization") version "2.0.21"
     id("com.github.ben-manes.versions") version "0.51.0"
-    id("com.android.library") version "8.7.1"
+    id("com.android.library") version "8.7.3"
     id("com.github.gmazzo.buildconfig") version "5.5.0"
     id("maven-publish")
     id("signing")
@@ -133,6 +133,10 @@ tasks.withType<KotlinNativeSimulatorTest>().configureEach {
     dependsOn("bootIOSSimulator")
     standalone.set(false)
     device.set(deviceName)
+}
+
+tasks.withType<Test> {
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
 }
 
 fun fromProjectOrEnv(key: String): String? = findProperty(key) as String? ?: System.getenv(key)

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -102,6 +102,7 @@ class Coordinator(
     )
 
     init {
+        resetStateIfPropertyDetailsChanged()
         persistState()
     }
 
@@ -111,6 +112,12 @@ class Coordinator(
         userData.ccpa?.consents?.uspstring.let { repository.uspString = it }
         userData.ccpa?.consents?.gppData.let { repository.gppData = it ?: emptyMap() }
         userData.usnat?.consents?.gppData.let { repository.gppData = it ?: emptyMap() }
+    }
+
+    private fun resetStateIfPropertyDetailsChanged() {
+        if (propertyId != state.propertyId || accountId != state.accountId) {
+            state = State(propertyId = propertyId, accountId = accountId)
+        }
     }
 
     private fun persistState() {

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -15,7 +15,7 @@ import com.sourcepoint.mobile_core.models.consents.GDPRConsent
 import com.sourcepoint.mobile_core.models.consents.SPUserData
 import com.sourcepoint.mobile_core.models.consents.State
 import com.sourcepoint.mobile_core.models.consents.USNatConsent
-import com.sourcepoint.mobile_core.network.SourcepointClient
+import com.sourcepoint.mobile_core.network.SPClient
 import com.sourcepoint.mobile_core.network.requests.CCPAChoiceRequest
 import com.sourcepoint.mobile_core.network.requests.ChoiceAllRequest
 import com.sourcepoint.mobile_core.network.requests.ConsentStatusRequest
@@ -46,8 +46,8 @@ class Coordinator(
     private val propertyName: SPPropertyName,
     private val campaigns: SPCampaigns,
     private val repository: Repository,
-    private val spClient: SourcepointClient,
-    private var state: State
+    private val spClient: SPClient,
+    internal var state: State
 ): ICoordinator {
     private var authId: String? = null
     private val idfaStatus: SPIDFAStatus? get() = SPIDFAStatus.current()

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -83,23 +83,24 @@ class Coordinator(
             usnat = campaigns.usnat?.let { SPUserData.SPConsent(consents = state.usNat.consents) }
         )
 
+    @Suppress("Unused")
     constructor(
         accountId: Int,
         propertyId: Int,
         propertyName: SPPropertyName,
         campaigns: SPCampaigns,
-        repository: Repository = Repository(),
-        initialState: State? = null
-    ) : this(
-        accountId,
-        propertyId,
-        propertyName,
-        campaigns,
-        repository,
-        spClient = SourcepointClient(accountId, propertyId, propertyName),
-        state = initialState ?: repository.state
-    ) {
-        repository.state = state
+        repository: Repository,
+        spClient: SPClient
+    ): this(
+        accountId = accountId,
+        propertyId = propertyId,
+        propertyName = propertyName,
+        campaigns = campaigns,
+        repository = repository,
+        spClient = spClient,
+        state = repository.state ?: State(accountId = accountId, propertyId = propertyId)
+    )
+
     init {
         persistState()
     }
@@ -122,7 +123,7 @@ class Coordinator(
         }
 
         if (authId != null && state.authId != authId) {
-            state = State(authId = authId)
+            state = State(authId = authId, propertyId = propertyId, accountId = accountId)
         }
         persistState()
     }

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/ICoordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/ICoordinator.kt
@@ -2,8 +2,8 @@ package com.sourcepoint.mobile_core
 
 import com.sourcepoint.mobile_core.models.MessageToDisplay
 import com.sourcepoint.mobile_core.models.SPAction
+import com.sourcepoint.mobile_core.models.SPMessageLanguage
 import com.sourcepoint.mobile_core.models.consents.SPUserData
-import com.sourcepoint.mobile_core.network.requests.ChoiceAllRequest
 import kotlinx.serialization.json.JsonObject
 
 interface ICoordinator {
@@ -13,7 +13,8 @@ interface ICoordinator {
 
     @Throws(Exception::class) suspend fun loadMessages(
         authId: String?,
-        pubData: JsonObject?
+        pubData: JsonObject?,
+        language: SPMessageLanguage
     ): List<MessageToDisplay>
 
     @Throws(Exception::class) suspend fun customConsentGDPR(

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPTargetingParams.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPTargetingParams.kt
@@ -1,3 +1,4 @@
 package com.sourcepoint.mobile_core.models
 
+// TODO: we should change this to a JsonObject
 typealias SPTargetingParams = Map<String, String>

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/SPUserData.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/SPUserData.kt
@@ -1,6 +1,8 @@
 package com.sourcepoint.mobile_core.models.consents
 
+import com.sourcepoint.mobile_core.network.encodeToJsonObject
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 data class SPUserData(
@@ -9,9 +11,15 @@ data class SPUserData(
     val usnat: SPConsent<USNatConsent>? = null
 ) {
     val webConsents: SPWebConsents get() = SPWebConsents(
-        gdpr = if (gdpr?.consents?.uuid != null) SPWebConsents.SPWebConsent(gdpr.consents.uuid, gdpr.consents.webConsentPayload) else null,
-        ccpa = if (ccpa?.consents?.uuid != null) SPWebConsents.SPWebConsent(ccpa.consents.uuid, ccpa.consents.webConsentPayload) else null,
-        usnat = if (usnat?.consents?.uuid != null) SPWebConsents.SPWebConsent(usnat.consents.uuid, usnat.consents.webConsentPayload) else null,
+        gdpr = gdpr?.consents?.uuid?.let {
+            SPWebConsents.SPWebConsent(it, gdpr.consents.webConsentPayload?.encodeToJsonObject())
+        },
+        ccpa = ccpa?.consents?.uuid?.let {
+            SPWebConsents.SPWebConsent(it, ccpa.consents.webConsentPayload?.encodeToJsonObject())
+        },
+        usnat = usnat?.consents?.uuid?.let {
+            SPWebConsents.SPWebConsent(it, usnat.consents.webConsentPayload?.encodeToJsonObject())
+        },
     )
 
     @Serializable
@@ -19,14 +27,13 @@ data class SPUserData(
         val consents: ConsentType?
     )
 
+    @Serializable
     data class SPWebConsents(
         val gdpr: SPWebConsent?,
         val ccpa: SPWebConsent?,
         val usnat: SPWebConsent?
     ) {
-        data class SPWebConsent(
-            val uuid: String,
-            val webConsentPayload: String?
-        )
+        @Serializable
+        data class SPWebConsent(val uuid: String, val webConsentPayload: JsonObject?)
     }
 }

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/State.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/State.kt
@@ -11,6 +11,8 @@ data class State (
     var usNat: USNatState = USNatState(),
     var ios14: AttCampaign = AttCampaign(),
     var authId: String? = null,
+    val propertyId: Int,
+    val accountId: Int,
     var localVersion: Int = VERSION,
     var localState: String = "",
     var nonKeyedLocalState: String = "",

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/storage/Repository.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/storage/Repository.kt
@@ -56,8 +56,8 @@ class Repository(private val storage: Settings) {
         get() = storage[USPSTRING_KEY]
         set(value) { storage[USPSTRING_KEY] = value }
 
-    var state: State
-        get() = Json.decodeFromString<State?>(storage.getString(SP_STATE_KEY, defaultValue = "{}")) ?: State()
+    var state: State?
+        get() = Json.decodeFromString<State?>(storage.getString(SP_STATE_KEY, defaultValue = ""))
         set(value) { storage[SP_STATE_KEY] = Json.encodeToString(value) }
 
     fun clear() {

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -6,21 +6,22 @@ import com.sourcepoint.mobile_core.models.SPActionType
 import com.sourcepoint.mobile_core.models.SPCampaign
 import com.sourcepoint.mobile_core.models.SPCampaignType
 import com.sourcepoint.mobile_core.models.SPCampaigns
+import com.sourcepoint.mobile_core.models.SPMessageLanguage
 import com.sourcepoint.mobile_core.models.SPPropertyName
 import com.sourcepoint.mobile_core.models.consents.State
+import com.sourcepoint.mobile_core.network.SPClient
 import com.sourcepoint.mobile_core.network.SourcepointClient
 import com.sourcepoint.mobile_core.network.encodeToJsonObject
 import com.sourcepoint.mobile_core.storage.Repository
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 
 class CoordinatorTest {
     private val storage = MapSettings()
     private val repository = Repository(storage)
-    private lateinit var coordinator: Coordinator
     private val accountId = 22
     private val propertyId = 16893
     private val propertyName = SPPropertyName.create("mobile.multicampaign.demo")
@@ -30,27 +31,46 @@ class CoordinatorTest {
         usnat = SPCampaign(),
         ios14 = SPCampaign(),
     )
+    private val state = State(accountId = accountId, propertyId = propertyId)
 
-    @BeforeTest
-    fun initCoordinatorState() {
-        coordinator = Coordinator(
+    private fun getCoordinator(
+        accountId: Int = this.accountId,
+        propertyId: Int = this.propertyId,
+        propertyName: SPPropertyName = this.propertyName,
+        campaigns: SPCampaigns = this.campaigns,
+        spClient: SPClient = SourcepointClient(
             accountId = accountId,
             propertyId = propertyId,
-            propertyName = propertyName,
-            campaigns = campaigns,
-            spClient = SourcepointClient(
-                accountId = accountId,
-                propertyId = propertyId,
-                propertyName = propertyName
-            ),
-            repository = repository,
-            state = State()
+            propertyName = propertyName
+        ),
+        repository: Repository = this.repository,
+        state: State = this.state
+    ) = Coordinator(
+        accountId = accountId,
+        propertyId = propertyId,
+        propertyName = propertyName,
+        campaigns = campaigns,
+        spClient = spClient,
+        repository = repository,
+        state = state
+    )
+
+    @Test
+    fun shouldResetStateIfPropertyDetailsChange() {
+        val state = State(propertyId = propertyId, accountId = accountId)
+        assertNotEquals(
+            getCoordinator(state = state).state,
+            getCoordinator(state = state, propertyId = 123).state
+        )
+        assertNotEquals(
+            getCoordinator(state = state).state,
+            getCoordinator(state = state, accountId = 123).state
         )
     }
 
     @Test
     fun reportActionReturnsGDPRConsent() = runTest {
-        val consents = coordinator.reportAction(
+        val consents = getCoordinator().reportAction(
             action = SPAction(type = SPActionType.AcceptAll, campaignType = SPCampaignType.Gdpr),
         )
         assertFalse(consents.gdpr?.consents?.uuid.isNullOrEmpty())
@@ -58,7 +78,7 @@ class CoordinatorTest {
 
     @Test
     fun reportActionReturnsCCPAConsent() = runTest {
-        val consents = coordinator.reportAction(
+        val consents = getCoordinator().reportAction(
             action = SPAction(type = SPActionType.RejectAll, campaignType = SPCampaignType.Ccpa),
         )
         assertFalse(consents.ccpa?.consents?.uuid.isNullOrEmpty())
@@ -66,7 +86,7 @@ class CoordinatorTest {
 
     @Test
     fun reportActionReturnsUSNatConsent() = runTest {
-        val consents = coordinator.reportAction(
+        val consents = getCoordinator().reportAction(
             action = SPAction(
                 type = SPActionType.SaveAndExit,
                 campaignType = SPCampaignType.UsNat,
@@ -86,10 +106,11 @@ class CoordinatorTest {
 
     @Test
     fun noMessagesShouldAppearAfterAcceptingAll() = runTest {
-        assertEquals(3, coordinator.loadMessages(authId = null, pubData = null).size)
+        val coordinator = getCoordinator()
+        assertEquals(3, coordinator.loadMessages(authId = null, pubData = null, language = SPMessageLanguage.ENGLISH).size)
         coordinator.reportAction(SPAction(SPActionType.AcceptAll, SPCampaignType.Gdpr))
         coordinator.reportAction(SPAction(SPActionType.AcceptAll, SPCampaignType.Ccpa))
         coordinator.reportAction(SPAction(SPActionType.AcceptAll, SPCampaignType.UsNat))
-        assertEquals(0, coordinator.loadMessages(authId = null, pubData = null).size)
+        assertEquals(0, coordinator.loadMessages(authId = null, pubData = null, language = SPMessageLanguage.ENGLISH).size)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 #Gradle
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.max-workers=4 
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
* run tests in parallel
* move language to loadMessages signature
* move `repository.state = state` to `persistState` function
* change Coordinator spClient from concrete implementation to receive `SPClient` interface
* add accountId and propertyId to `State`
* reset state if stored property/accountId change
* refactor `SPUserData` webconsents
* add note to `SPTargetingParams`