### PR TITLE
Implement uspstring logic

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -565,7 +565,6 @@ class Coordinator(
                     expirationDate = it.expirationDate ?: it.dateCreated?.inOneYear() ?: now().inOneYear(),
                     status = it.status,
                     gppData = it.gppData,
-                    uspstring = it.uspstring,
                 )
             )
         }
@@ -719,7 +718,6 @@ class Coordinator(
                 rejectedVendors = postResponse.rejectedVendors ?: getResponse?.ccpa?.rejectedVendors?: emptyList(),
                 rejectedCategories = postResponse.rejectedCategories ?: getResponse?.ccpa?.rejectedCategories ?: emptyList(),
                 webConsentPayload = postResponse.webConsentPayload ?: getResponse?.ccpa?.webConsentPayload,
-                uspstring = postResponse.uspstring ?: getResponse?.ccpa?.uspstring
             )
         )
         if (action.type == SPActionType.SaveAndExit) {

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/CCPAConsent.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/CCPAConsent.kt
@@ -6,7 +6,6 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// TODO: implement USPString logic
 @Serializable
 data class CCPAConsent(
     val applies: Boolean = false,
@@ -14,7 +13,6 @@ data class CCPAConsent(
     val dateCreated: Instant = now(),
     val expirationDate: Instant = dateCreated.inOneYear(),
     val signedLspa: Boolean? = null,
-    val uspstring: String? = null,
     val rejectedAll: Boolean = false,
     val consentedAll: Boolean = false,
     val rejectedVendors: List<String> = emptyList(),
@@ -23,6 +21,20 @@ data class CCPAConsent(
     val webConsentPayload: String? = null,
     @SerialName("GPPData") var gppData: IABData = emptyMap(),
 ) {
+    val uspstring: String get() {
+        val version = 1
+        val hadChanceToOptOut = true
+
+        return if (applies) {
+            "$version" +
+                (if (hadChanceToOptOut) "Y" else "N") +
+                (if (status == CCPAConsentStatus.RejectedAll || status == CCPAConsentStatus.RejectedSome) "Y" else "N") +
+                (if (signedLspa == true) "Y" else "N")
+        } else {
+            "$version---"
+        }
+    }
+
     @Serializable
     enum class CCPAConsentStatus {
         @SerialName("consentedAll") ConsentedAll,

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/responses/CCPAChoiceResponse.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/responses/CCPAChoiceResponse.kt
@@ -13,7 +13,6 @@ class CCPAChoiceResponse (
     val consentedAll: Boolean? = null,
     val rejectedAll: Boolean? = null,
     val status: CCPAConsent.CCPAConsentStatus? = null,
-    val uspstring: String? = null,
     val gpcEnabled: Boolean? = null,
     val rejectedVendors: List<String>? = null,
     val rejectedCategories: List<String>? = null,

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/responses/ChoiceAllResponse.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/responses/ChoiceAllResponse.kt
@@ -51,7 +51,6 @@ data class ChoiceAllResponse (
         val expirationDate: Instant?,
         val rejectedAll: Boolean,
         val status: CCPAConsent.CCPAConsentStatus,
-        @SerialName("uspString") val uspstring: String,
         val rejectedVendors: List<String>,
         val rejectedCategories: List<String>,
         val gpcEnabled: Boolean?,

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -205,4 +205,18 @@ class CoordinatorTest {
 
         assertEquals(0, coordinator.loadMessages(authId = null, pubData = null, language = ENGLISH).size)
     }
+
+    @Test
+    fun whenALegislationDoesNotApplyMessageIsReturnedRegardless() = runTest {
+        val spClientMock = SPClientMock(
+            original = spClient,
+            getMetaData = { MetaDataResponse(
+                ccpa = MetaDataResponse.MetaDataResponseCCPA(applies = false, sampleRate = 1.0f)
+            )
+        })
+        val coordinator = getCoordinator(spClient = spClientMock, campaigns = SPCampaigns(ccpa = SPCampaign()))
+        val messages = coordinator.loadMessages(authId = null, pubData = null, language = ENGLISH)
+        assertEquals(1, messages.size)
+        assertNotEmpty(repository.uspString)
+    }
 }

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/mocks/SPClientMock.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/mocks/SPClientMock.kt
@@ -26,45 +26,62 @@ import com.sourcepoint.mobile_core.network.responses.PvDataResponse
 import com.sourcepoint.mobile_core.network.responses.USNatChoiceResponse
 
 class SPClientMock(
-    val getMetaData: () -> MetaDataResponse = { MetaDataResponse() },
-    val postPvData: () -> PvDataResponse = { PvDataResponse() },
-    val getConsentStatus: () -> ConsentStatusResponse = {
-        ConsentStatusResponse(
-            consentStatusData = ConsentStatusResponse.ConsentStatusData(),
-            localState = ""
-        )
-    },
-    val postChoiceGDPRAction: () -> GDPRChoiceResponse = { GDPRChoiceResponse(uuid = "") },
-    val postChoiceCCPAAction: () -> CCPAChoiceResponse = { CCPAChoiceResponse(uuid = "") },
-    val postChoiceUSNATAction: () -> USNatChoiceResponse = { USNatChoiceResponse(
-        consentStatus = ConsentStatus(),
-        consentStrings = emptyList(),
-        userConsents = USNatConsent.USNatUserConsents()
-    ) },
-    val getChoiceAll: () -> ChoiceAllResponse = { ChoiceAllResponse() },
-    val getMessages: () -> MessagesResponse = { MessagesResponse(
-        campaigns = emptyList(),
-        localState = "",
-        nonKeyedLocalState = ""
-    ) },
-    val customConsentGDPR: () -> GDPRConsent = { GDPRConsent() },
-    val deleteCustomConsentGDPR: () -> GDPRConsent = { GDPRConsent() },
+    private val original: SPClient? = null,
+    private val getMetaData: (() -> MetaDataResponse?)? = null,
+    private val postPvData: (() -> PvDataResponse?)? = null,
+    private val getConsentStatus: (() -> ConsentStatusResponse?)? = null,
+    private val postChoiceGDPRAction: (() -> GDPRChoiceResponse?)? = null,
+    private val postChoiceCCPAAction: (() -> CCPAChoiceResponse?)? = null,
+    private val postChoiceUSNATAction: (() -> USNatChoiceResponse?)? = null,
+    private val getChoiceAll: (() -> ChoiceAllResponse?)? = null,
+    private val getMessages: (() -> MessagesResponse?)? = null,
+    private val customConsentGDPR: (() -> GDPRConsent?)? = null,
+    private val deleteCustomConsentGDPR: (() -> GDPRConsent?)? = null,
+) : SPClient {
+    override suspend fun getMetaData(campaigns: MetaDataRequest.Campaigns) =
+        getMetaData?.invoke() ?:
+            original?.getMetaData(campaigns) ?:
+            MetaDataResponse()
 
-): SPClient {
+    override suspend fun postPvData(request: PvDataRequest) =
+        postPvData?.invoke() ?:
+            original?.postPvData(request) ?:
+            PvDataResponse()
 
-    override suspend fun getMetaData(campaigns: MetaDataRequest.Campaigns) = getMetaData()
-    override suspend fun postPvData(request: PvDataRequest) = postPvData()
     override suspend fun getConsentStatus(authId: String?, metadata: ConsentStatusRequest.MetaData) =
-        getConsentStatus()
+        getConsentStatus?.invoke() ?:
+            original?.getConsentStatus(authId, metadata) ?:
+            ConsentStatusResponse(consentStatusData = ConsentStatusResponse.ConsentStatusData(), localState = "")
+
     override suspend fun postChoiceGDPRAction(actionType: SPActionType, request: GDPRChoiceRequest) =
-        postChoiceGDPRAction()
+        postChoiceGDPRAction?.invoke() ?:
+            original?.postChoiceGDPRAction(actionType, request) ?:
+            GDPRChoiceResponse(uuid = "")
+
     override suspend fun postChoiceCCPAAction(actionType: SPActionType, request: CCPAChoiceRequest) =
-        postChoiceCCPAAction()
+        postChoiceCCPAAction?.invoke() ?:
+            original?.postChoiceCCPAAction(actionType, request) ?:
+            CCPAChoiceResponse(uuid = "")
+
     override suspend fun postChoiceUSNatAction(actionType: SPActionType, request: USNatChoiceRequest) =
-        postChoiceUSNATAction()
+        postChoiceUSNATAction?.invoke() ?:
+            original?.postChoiceUSNatAction(actionType, request) ?:
+            USNatChoiceResponse(
+                consentStatus = ConsentStatus(),
+                consentStrings = emptyList(),
+                userConsents = USNatConsent.USNatUserConsents()
+            )
+
     override suspend fun getChoiceAll(actionType: SPActionType, campaigns: ChoiceAllRequest.ChoiceAllCampaigns) =
-        getChoiceAll()
-    override suspend fun getMessages(request: MessagesRequest) = getMessages()
+        getChoiceAll?.invoke() ?:
+            original?.getChoiceAll(actionType, campaigns) ?:
+            ChoiceAllResponse()
+
+    override suspend fun getMessages(request: MessagesRequest) =
+        getMessages?.invoke() ?:
+            original?.getMessages(request) ?:
+            MessagesResponse(campaigns = emptyList(), localState = "", nonKeyedLocalState = "")
+
     override suspend fun postReportIdfaStatus(
         propertyId: Int?,
         uuid: String?,
@@ -74,7 +91,9 @@ class SPClientMock(
         idfaStatus: SPIDFAStatus,
         iosVersion: String,
         partitionUUID: String?
-    ) {}
+    ) {
+        original?.postReportIdfaStatus(propertyId, uuid, requestUUID, uuidType, messageId, idfaStatus, iosVersion, partitionUUID)
+    }
 
     override suspend fun customConsentGDPR(
         consentUUID: String,
@@ -82,7 +101,10 @@ class SPClientMock(
         vendors: List<String>,
         categories: List<String>,
         legIntCategories: List<String>
-    ) = customConsentGDPR()
+    ) =
+        customConsentGDPR?.invoke() ?:
+            original?.customConsentGDPR(consentUUID, propertyId, vendors, categories, legIntCategories) ?:
+            GDPRConsent()
 
     override suspend fun deleteCustomConsentGDPR(
         consentUUID: String,
@@ -90,7 +112,12 @@ class SPClientMock(
         vendors: List<String>,
         categories: List<String>,
         legIntCategories: List<String>
-    ) =  deleteCustomConsentGDPR()
+    ) =
+        deleteCustomConsentGDPR?.invoke() ?:
+            original?.deleteCustomConsentGDPR(consentUUID, propertyId, vendors, categories, legIntCategories) ?:
+            GDPRConsent()
 
-    override suspend fun errorMetrics(error: SPError) {}
+    override suspend fun errorMetrics(error: SPError) {
+        original?.errorMetrics(error)
+    }
 }

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/models/consents/CCPAConsentTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/models/consents/CCPAConsentTest.kt
@@ -1,0 +1,41 @@
+package com.sourcepoint.mobile_core.models.consents
+
+import com.sourcepoint.mobile_core.models.consents.CCPAConsent.CCPAConsentStatus.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CCPAConsentTest {
+    @Test
+    fun uspstringIs1YYYWhenAppliesIsTrueSignedLspaIsTrueAndStatusIsRejectedAllOrSome() {
+        arrayOf(RejectedSome, RejectedAll).forEach { status ->
+            val consent = CCPAConsent(applies = true, signedLspa = true, status = status)
+            assertEquals("1YYY", consent.uspstring)
+        }
+    }
+
+    @Test
+    fun uspstringIs1YYNWhenAppliesIsTrueSignedLspaIsFalseAndStatusIsRejectedAllOrSome() {
+        arrayOf(RejectedSome, RejectedAll).forEach { status ->
+            val consent = CCPAConsent(applies = true, signedLspa = false, status = status)
+            assertEquals("1YYN", consent.uspstring)
+        }
+    }
+
+    @Test
+    fun uspstringIs1YNYWhenAppliesIsTrueSignedLspaIsTrueAndStatusIsConsentedAll() {
+        val consent = CCPAConsent(applies = true, signedLspa = true, status = ConsentedAll)
+        assertEquals("1YNY", consent.uspstring)
+    }
+
+    @Test
+    fun uspstringIs1YNNAppliesIsTrueSignedLspaIsFalseAndStatusIsConsentedAll() {
+        val consent = CCPAConsent(applies = true, signedLspa = false, status = ConsentedAll)
+        assertEquals("1YNN", consent.uspstring)
+    }
+
+    @Test
+    fun uspstringIs1___WhenAppliesIsFalse() {
+        val consent = CCPAConsent(applies = false)
+        assertEquals("1---", consent.uspstring)
+    }
+}


### PR DESCRIPTION
* implement `uspstring` logic and add tests to it
* refactor `SPClientMock` to allow calls to pass through
* refactor `CoordinatorTests`
* add test for `loadMessages` when a legislation does not apply