### PR TITLE
Fix for ios14 campaign: custom getter for `idfaStatus`

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -65,7 +65,7 @@ class Coordinator(
 ): ICoordinator {
     @Suppress("Unused") var translateMessage: Boolean? = null; set(value) { includeData.translateMessage = value; field = value }
     private val idfaStatus: SPIDFAStatus? get() = getIDFAStatus()
-    var getIDFAStatus: (() -> SPIDFAStatus?) = { SPIDFAStatus.current() }
+    public var getIDFAStatus: (() -> SPIDFAStatus?) = { SPIDFAStatus.current() } //workaround for ios
     private val includeData: IncludeData = IncludeData()
 
     private var needsNewUSNatData = false

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -64,7 +64,8 @@ class Coordinator(
     internal var state: State = repository.state ?: State(accountId = accountId, propertyId = propertyId)
 ): ICoordinator {
     @Suppress("Unused") var translateMessage: Boolean? = null; set(value) { includeData.translateMessage = value; field = value }
-    private val idfaStatus: SPIDFAStatus? get() = SPIDFAStatus.current()
+    private val idfaStatus: SPIDFAStatus? get() = getIDFAStatus()
+    var getIDFAStatus: (() -> SPIDFAStatus?) = { SPIDFAStatus.current() }
     private val includeData: IncludeData = IncludeData()
 
     private var needsNewUSNatData = false

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPIDFAStatus.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/SPIDFAStatus.kt
@@ -2,9 +2,6 @@ package com.sourcepoint.mobile_core.models
 
 import kotlinx.serialization.SerialName
 
-// TODO implement IDFA logic for both platforms
-// - Android should default to null
-// - iOS should have logic to get it from OS
 enum class SPIDFAStatus {
     @SerialName("unknown") Unknown,
     @SerialName("accepted") Accepted,


### PR DESCRIPTION
This change might look strange, BUT that's the only way I found to do it.

Please, note that in the iOS SDK https://github.com/SourcePointUSA/ios-cmp-app/pull/595/files we reassign the getting of mobile-core's `idfaStatus` to the getting of native `idfaStatus`. 
Therefore, when mobile-core will refer to `idfaStatus` while running in iOS environment, it will refer to the following Swift code from iOS SDK: 
``` 
var idfaStatus: SPIDFAStatus { SPIDFAStatus.current() }
```

That :point_up: should explain why using public getter doesn't work.