### PR TITLE
Implement `runTestWithRetries`

### DIFF
--- a/core/src/androidUnitTest/kotlin/com/sourcepoint/mobile_core/network/DefaultRequestTest.kt
+++ b/core/src/androidUnitTest/kotlin/com/sourcepoint/mobile_core/network/DefaultRequestTest.kt
@@ -2,13 +2,12 @@ package com.sourcepoint.mobile_core.network
 
 import com.sourcepoint.core.BuildConfig
 import com.sourcepoint.mobile_core.network.requests.DefaultRequest
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DefaultRequestTest {
     @Test
-    fun containsTheRightAttributes() = runTest {
+    fun containsTheRightAttributes() {
         val request = DefaultRequest()
         assertEquals("mobile-core-Android", request.scriptType)
         assertEquals(BuildConfig.Version, request.scriptVersion)

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/EncodeToQueryParamsTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/EncodeToQueryParamsTest.kt
@@ -1,7 +1,6 @@
 package com.sourcepoint.mobile_core.network
 
 import com.sourcepoint.mobile_core.network.requests.toQueryParams
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
@@ -32,7 +31,7 @@ class EncodeToQueryParamsTest {
     )
 
     @Test
-    fun encodesSerializableClassToQueryParams() = runTest {
+    fun encodesSerializableClassToQueryParams() {
         assertEquals(
             mapOf(
                 "intValue" to "42",
@@ -47,7 +46,7 @@ class EncodeToQueryParamsTest {
     }
 
     @Test
-    fun canEncodeNulls() = runTest {
+    fun canEncodeNulls() {
         val encoded = dummyClass.toQueryParams(omitNulls = false)
         assertEquals(encoded["objectValue"], "{\"foo\":\"hello world\",\"anotherNullable\":null}")
         assertNull(encoded["nullableValue"])

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/IncludeDataTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/IncludeDataTest.kt
@@ -1,14 +1,13 @@
 package com.sourcepoint.mobile_core.network
 
 import com.sourcepoint.mobile_core.network.requests.IncludeData
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class IncludeDataTest {
     @Test
-    fun defaultValues() = runTest {
+    fun defaultValues() {
         val includeData = IncludeData().toString()
         assertEquals(
             "{\"TCData\":{\"type\":\"string\"},\"webConsentPayload\":{\"type\":\"string\"},\"localState\":{\"type\":\"string\"},\"categories\":true,\"GPPData\":{\"uspString\":true}}",
@@ -17,7 +16,7 @@ class IncludeDataTest {
     }
 
     @Test
-    fun withTranslatedMessages() = runTest {
+    fun withTranslatedMessages() {
         val includeData = IncludeData(translateMessage = true).toString()
         assertContains(includeData, "\"translateMessage\":true")
     }

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
@@ -25,6 +25,7 @@ import com.sourcepoint.mobile_core.network.requests.MessagesRequest
 import com.sourcepoint.mobile_core.network.requests.MetaDataRequest
 import com.sourcepoint.mobile_core.network.requests.USNatChoiceRequest
 import com.sourcepoint.mobile_core.network.responses.MessagesResponse
+import com.sourcepoint.mobile_core.utils.runTestWithRetries
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
@@ -32,7 +33,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -62,7 +62,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun getMetaData() = runTest {
+    fun getMetaData() = runTestWithRetries {
         val response = api.getMetaData(
             MetaDataRequest.Campaigns(
                 gdpr = MetaDataRequest.Campaigns.Campaign(groupPmId = "123"),
@@ -85,7 +85,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun getConsentStatus() = runTest {
+    fun getConsentStatus() = runTestWithRetries {
         val response = api.getConsentStatus(
             authId = null,
             metadata = ConsentStatusRequest.MetaData(
@@ -162,7 +162,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun getMessages() = runTest {
+    fun getMessages() = runTestWithRetries {
         val response = api.getMessages(
             MessagesRequest(
                 body = MessagesRequest.Body(
@@ -218,7 +218,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun loggingWithErrorWhenRequestTimeoutInTheClient() = runTest {
+    fun loggingWithErrorWhenRequestTimeoutInTheClient() = runTestWithRetries {
         val mockEngine = mock(delayInSeconds = 2)
 
         assertFailsWith<SPClientTimeout> {
@@ -228,7 +228,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun loggingWithErrorWhenStatusCodeNot200() = runTest {
+    fun loggingWithErrorWhenStatusCodeNot200() = runTestWithRetries {
         val mockEngine = mock(status = HttpStatusCode.GatewayTimeout.value)
 
         assertFailsWith<SPNetworkError> {
@@ -241,7 +241,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun loggingWithErrorWhenResponseCantBeParsed() = runTest {
+    fun loggingWithErrorWhenResponseCantBeParsed() = runTestWithRetries {
         val mockEngine = mock(response = """{"gdpr":{}}""")
 
         assertFailsWith<SPUnableToParseBodyError> {
@@ -254,7 +254,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun canAddAndRemoveCustomConsentsInGDPR() = runTest {
+    fun canAddAndRemoveCustomConsentsInGDPR() = runTestWithRetries {
         val customVendorId = "5ff4d000a228633ac048be41"
         val categoryId1 = "608bad95d08d3112188e0e36"
         val categoryId2 = "608bad95d08d3112188e0e2f"
@@ -284,7 +284,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun getGDPRChoiceAcceptAllContainCorrectResponse() = runTest {
+    fun getGDPRChoiceAcceptAllContainCorrectResponse() = runTestWithRetries {
         val response = api.getChoiceAll(
             actionType = SPActionType.AcceptAll,
             campaigns = ChoiceAllRequest.ChoiceAllCampaigns(
@@ -299,7 +299,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun getGDPRChoiceRejectAllContainCorrectResponse() = runTest {
+    fun getGDPRChoiceRejectAllContainCorrectResponse() = runTestWithRetries {
         val response = api.getChoiceAll(
             actionType = SPActionType.RejectAll,
             campaigns = ChoiceAllRequest.ChoiceAllCampaigns(
@@ -314,7 +314,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postGDPRChoiceActionAcceptContainCorrectResponse() = runTest {
+    fun postGDPRChoiceActionAcceptContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceGDPRAction(
             actionType = SPActionType.AcceptAll,
             request = GDPRChoiceRequest(sendPVData = true, propertyId = 123, sampleRate = 1.0f)
@@ -325,7 +325,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postGDPRChoiceActionRejectContainCorrectResponse() = runTest {
+    fun postGDPRChoiceActionRejectContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceGDPRAction(
             actionType = SPActionType.RejectAll,
             request = GDPRChoiceRequest(sendPVData = true, propertyId = 123, sampleRate = 1.0f)
@@ -336,7 +336,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postGDPRChoiceActionSaveExitContainCorrectResponse() = runTest {
+    fun postGDPRChoiceActionSaveExitContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceGDPRAction(
             actionType = SPActionType.SaveAndExit,
             request = GDPRChoiceRequest(
@@ -361,7 +361,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postCCPAChoiceActionAcceptContainCorrectResponse() = runTest {
+    fun postCCPAChoiceActionAcceptContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceCCPAAction(
             actionType = SPActionType.AcceptAll,
             request = CCPAChoiceRequest(sendPVData = true, propertyId = propertyId, sampleRate = 1.0f)
@@ -371,7 +371,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postCCPAChoiceActionRejectContainCorrectResponse() = runTest {
+    fun postCCPAChoiceActionRejectContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceCCPAAction(
             actionType = SPActionType.RejectAll,
             request = CCPAChoiceRequest(sendPVData = true, propertyId = propertyId, sampleRate = 1.0f)
@@ -381,7 +381,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postCCPAChoiceActionSaveExitContainCorrectResponse() = runTest {
+    fun postCCPAChoiceActionSaveExitContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceCCPAAction(
             actionType = SPActionType.SaveAndExit,
             request = CCPAChoiceRequest(
@@ -399,7 +399,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postUSNatChoiceActionAcceptContainCorrectResponse() = runTest {
+    fun postUSNatChoiceActionAcceptContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceUSNatAction(
             actionType = SPActionType.AcceptAll,
             request = USNatChoiceRequest(sendPVData = true, propertyId = propertyId, sampleRate = 1.0f)
@@ -408,7 +408,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postUSNatChoiceActionRejectContainCorrectResponse() = runTest {
+    fun postUSNatChoiceActionRejectContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceUSNatAction(
             actionType = SPActionType.RejectAll,
             request = USNatChoiceRequest(sendPVData = true, propertyId = propertyId, sampleRate = 1.0f)
@@ -417,7 +417,7 @@ class SourcepointClientTest {
     }
 
     @Test
-    fun postUSNatChoiceActionSaveExitContainCorrectResponse() = runTest {
+    fun postUSNatChoiceActionSaveExitContainCorrectResponse() = runTestWithRetries {
         val response = api.postChoiceUSNatAction(
             actionType = SPActionType.SaveAndExit,
             request = USNatChoiceRequest(

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/responses/MessagesResponseTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/responses/MessagesResponseTest.kt
@@ -1,6 +1,5 @@
 package com.sourcepoint.mobile_core.network.responses
 
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json.Default.encodeToString
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
@@ -8,7 +7,7 @@ import kotlin.test.assertEquals
 
 class MessagesResponseTest {
     @Test
-    fun encodeToJsonTest() = runTest {
+    fun encodeToJsonTest() {
         val message = MessagesResponse.Message(
             categories = null,
             language = null,

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/DefaultEnumSerializerTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/DefaultEnumSerializerTest.kt
@@ -1,7 +1,6 @@
 package com.sourcepoint.mobile_core.utils
 
 import com.sourcepoint.mobile_core.network.json
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
@@ -15,7 +14,7 @@ class DefaultEnumSerializerTest {
     }
 
     @Test
-    fun serializingEnumsIsCaseInsensitive() = runTest {
+    fun serializingEnumsIsCaseInsensitive() {
         assertEquals(MyEnum.Foo, json.decodeFromString("\"Foo\""))
         assertEquals(MyEnum.Foo, json.decodeFromString("\"foo\""))
 

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/IntEnumSerializerTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/IntEnumSerializerTest.kt
@@ -21,17 +21,17 @@ data class DummyWithEnum(val enumProperty: IntTestEnum)
 
 class IntEnumSerializerTest {
     @Test
-    fun encodeToIntString() = runTest {
+    fun encodeToIntString() {
         assertEquals("2", json.encodeToString(IntTestEnum.Foo))
     }
 
     @Test
-    fun decodeFromInt() = runTest {
+    fun decodeFromInt() {
         assertEquals(IntTestEnum.Bar, json.decodeFromString( "99"))
     }
 
     @Test
-    fun encodeToIntInsideObject() = runTest {
+    fun encodeToIntInsideObject() {
         assertEquals(
             "{\"enumProperty\":2}",
             json.encodeToString(DummyWithEnum(enumProperty = IntTestEnum.Foo))
@@ -39,7 +39,7 @@ class IntEnumSerializerTest {
     }
 
     @Test
-    fun decodeFromIntInsideObject() = runTest {
+    fun decodeFromIntInsideObject() {
         assertEquals(
             DummyWithEnum(enumProperty = IntTestEnum.Bar),
             json.decodeFromString("{\"enumProperty\":99}")
@@ -47,7 +47,7 @@ class IntEnumSerializerTest {
     }
 
     @Test
-    fun decodeToDefaultValue() = runTest {
+    fun decodeToDefaultValue() {
         assertEquals(IntTestEnum.Unknown, json.decodeFromString( "0"))
     }
 }

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/StringEnumWithDefaultSerializerTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/StringEnumWithDefaultSerializerTest.kt
@@ -1,7 +1,6 @@
 package com.sourcepoint.mobile_core.utils
 
 import com.sourcepoint.mobile_core.network.json
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlin.test.Test
@@ -21,17 +20,17 @@ class StringEnumWithDefaultSerializerTest {
     data class DummyWithStringEnum(val enumProperty: StringTestEnum)
 
     @Test
-    fun encodeToString() = runTest {
+    fun encodeToString() {
         assertEquals("\"Foo\"", json.encodeToString(StringTestEnum.Foo))
     }
 
     @Test
-    fun decodeFromString() = runTest {
+    fun decodeFromString() {
         assertEquals(StringTestEnum.Bar, json.decodeFromString("\"Bar\""))
     }
 
     @Test
-    fun encodeToStringInsideObject() = runTest {
+    fun encodeToStringInsideObject() {
         assertEquals(
             "{\"enumProperty\":\"Foo\"}",
             json.encodeToString(DummyWithStringEnum(enumProperty = StringTestEnum.Foo))
@@ -39,7 +38,7 @@ class StringEnumWithDefaultSerializerTest {
     }
 
     @Test
-    fun decodeFromStringInsideObject() = runTest {
+    fun decodeFromStringInsideObject() {
         assertEquals(
             DummyWithStringEnum(enumProperty = StringTestEnum.Bar),
             json.decodeFromString("{\"enumProperty\":\"Bar\"}")
@@ -47,7 +46,7 @@ class StringEnumWithDefaultSerializerTest {
     }
 
     @Test
-    fun decodeToDefaultValue() = runTest {
+    fun decodeToDefaultValue() {
         assertEquals(StringTestEnum.Unknown, json.decodeFromString( "\"etc\""))
     }
 }

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/runTestWithRetries.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/runTestWithRetries.kt
@@ -1,0 +1,22 @@
+package com.sourcepoint.mobile_core.utils
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.fail
+
+fun runTestWithRetries(upToTimes: Int = 5, block: suspend () -> Unit) {
+    var lastError: Throwable? = null
+
+    repeat(upToTimes) { attempt ->
+        try {
+            runTest {
+                block()
+            }
+            return
+        } catch (e: Throwable) {
+            lastError = e
+            println("Test failed on attempt ${attempt + 1}/$upToTimes: ${e.message}")
+        }
+    }
+
+    fail("Test failed after $upToTimes attempts. Last error: ${lastError?.message}")
+}

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/runTestWithRetries.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/utils/runTestWithRetries.kt
@@ -1,22 +1,43 @@
 package com.sourcepoint.mobile_core.utils
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlin.math.pow
 import kotlin.test.fail
 
-fun runTestWithRetries(upToTimes: Int = 5, block: suspend () -> Unit) {
-    var lastError: Throwable? = null
+fun runTestWithRetries(
+    upToTimes: Int = 5,
+    initialDelayMillis: Long = 300,
+    backoffFactor: Double = 2.0,
+    useExponentialBackoff: Boolean = true,
+    block: suspend () -> Unit
+) {
+    runBlocking {
+        var lastError: Throwable? = null
 
-    repeat(upToTimes) { attempt ->
-        try {
-            runTest {
-                block()
+        repeat(upToTimes) { attempt ->
+            try {
+                runTest {
+                    block()
+                }
+                return@runBlocking
+            } catch (e: Throwable) {
+                lastError = e
+                println("Test failed on attempt ${attempt + 1}/$upToTimes: ${e.message}")
+
+                if (attempt <= upToTimes) {
+                    val delayTime = if (useExponentialBackoff) {
+                        (initialDelayMillis * backoffFactor.pow(attempt + 1)).toLong()
+                    } else {
+                        initialDelayMillis
+                    }
+                    println("Delaying for ${delayTime}ms before retrying...")
+                    delay(delayTime)
+                }
             }
-            return
-        } catch (e: Throwable) {
-            lastError = e
-            println("Test failed on attempt ${attempt + 1}/$upToTimes: ${e.message}")
         }
-    }
 
-    fail("Test failed after $upToTimes attempts. Last error: ${lastError?.message}")
+        fail("Test failed after $upToTimes attempts. Last error: ${lastError?.message}")
+    }
 }

--- a/core/src/iosTest/kotlin/network/DefaultRequestTest.kt
+++ b/core/src/iosTest/kotlin/network/DefaultRequestTest.kt
@@ -2,13 +2,12 @@ package network
 
 import com.sourcepoint.core.BuildConfig
 import com.sourcepoint.mobile_core.network.requests.DefaultRequest
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DefaultRequestTest {
     @Test
-    fun containsTheRightAttributes() = runTest {
+    fun containsTheRightAttributes() {
         val request = DefaultRequest()
         assertEquals("mobile-core-iOS", request.scriptType)
         assertEquals(BuildConfig.Version, request.scriptVersion)

--- a/core/src/tvosTest/kotlin/network/DefaultRequestTest.kt
+++ b/core/src/tvosTest/kotlin/network/DefaultRequestTest.kt
@@ -2,13 +2,12 @@ package network
 
 import com.sourcepoint.core.BuildConfig
 import com.sourcepoint.mobile_core.network.requests.DefaultRequest
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DefaultRequestTest {
     @Test
-    fun containsTheRightAttributes() = runTest {
+    fun containsTheRightAttributes() {
         val request = DefaultRequest()
         assertEquals("mobile-core-tvOS", request.scriptType)
         assertEquals(BuildConfig.Version, request.scriptVersion)


### PR DESCRIPTION
* remove `runTest` function where not needed (it's only needed for tests that use `suspend` functions)
* implement `runTestWithRetries`
  * allows for custom retries amount
  * uses exponential backoff delay (will wait increasingly longer before trying running the test again, useful for tests that use network requests)