### PR TITLE
Fix deleteCustomConsent and customMetrics requests

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -56,16 +56,13 @@ class Coordinator(
     private val propertyName: SPPropertyName,
     private val campaigns: SPCampaigns,
     private val repository: Repository = Repository(),
-    private val spClient: SPClient = SourcepointClient(
-        accountId = accountId,
-        propertyId = propertyId,
-        propertyName = propertyName,
-    ),
+    private val spClient: SPClient = SourcepointClient(accountId = accountId, propertyId = propertyId),
     private var authId: String? = null,
     internal var state: State = repository.state ?: State(accountId = accountId, propertyId = propertyId)
 ): ICoordinator {
     private val idfaStatus: SPIDFAStatus? get() = getIDFAStatus()
-    public var getIDFAStatus: (() -> SPIDFAStatus?) = { SPIDFAStatus.current() } //workaround for ios
+    // TODO: implement using expect/actual
+    var getIDFAStatus: (() -> SPIDFAStatus?) = { SPIDFAStatus.current() } // workaround for ios
     private val includeData: IncludeData = IncludeData()
 
     private var needsNewUSNatData = false

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/ErrorMetricsRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/ErrorMetricsRequest.kt
@@ -1,20 +1,15 @@
 package com.sourcepoint.mobile_core.network
 
 import com.sourcepoint.mobile_core.models.SPCampaignType
-import com.sourcepoint.mobile_core.models.SPPropertyName
-import com.sourcepoint.mobile_core.network.requests.DefaultRequest
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ErrorMetricsRequest(
     val code: String,
     val accountId: String,
-    val description: String,
-    val sdkVersion: String,
-    @SerialName("OSVersion") val osVersion: String,
+    val scriptVersion: String,
+    val legislation: SPCampaignType?,
+    val sdkOsVersion: String,
     val deviceFamily: String,
     val propertyId: String,
-    val propertyName: SPPropertyName,
-    val campaignType: SPCampaignType?
-): DefaultRequest()
+)

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
@@ -8,7 +8,6 @@ import com.sourcepoint.mobile_core.models.SPCampaignType
 import com.sourcepoint.mobile_core.models.SPError
 import com.sourcepoint.mobile_core.models.SPIDFAStatus
 import com.sourcepoint.mobile_core.models.SPNetworkError
-import com.sourcepoint.mobile_core.models.SPPropertyName
 import com.sourcepoint.mobile_core.models.SPUnableToParseBodyError
 import com.sourcepoint.mobile_core.models.consents.GDPRConsent
 import com.sourcepoint.mobile_core.network.requests.CCPAChoiceRequest
@@ -129,7 +128,6 @@ interface SPClient {
 class SourcepointClient(
     private val accountId: Int,
     private val propertyId: Int,
-    private val propertyName: SPPropertyName,
     httpEngine: HttpClientEngine?,
     private val device: DeviceInformation,
     private val version: String,
@@ -165,12 +163,10 @@ class SourcepointClient(
     constructor(
         accountId: Int,
         propertyId: Int,
-        propertyName: SPPropertyName,
         requestTimeoutInSeconds: Int = 5
     ) : this(
         accountId,
         propertyId,
-        propertyName,
         httpEngine = null,
         device = DeviceInformation(),
         version = BuildConfig.Version,
@@ -180,13 +176,11 @@ class SourcepointClient(
     constructor(
         accountId: Int,
         propertyId: Int,
-        propertyName: SPPropertyName,
         httpEngine: HttpClientEngine,
         requestTimeoutInSeconds: Int = 5,
     ) : this(
         accountId,
         propertyId,
-        propertyName,
         httpEngine = httpEngine,
         device = DeviceInformation(),
         version = BuildConfig.Version,

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/SourcepointClient.kt
@@ -16,6 +16,7 @@ import com.sourcepoint.mobile_core.network.requests.ChoiceAllRequest
 import com.sourcepoint.mobile_core.network.requests.ConsentStatusRequest
 import com.sourcepoint.mobile_core.network.requests.CustomConsentRequest
 import com.sourcepoint.mobile_core.network.requests.DefaultRequest
+import com.sourcepoint.mobile_core.network.requests.DeleteCustomConsentRequest
 import com.sourcepoint.mobile_core.network.requests.GDPRChoiceRequest
 import com.sourcepoint.mobile_core.network.requests.IDFAStatusReportRequest
 import com.sourcepoint.mobile_core.network.requests.MessagesRequest
@@ -350,9 +351,8 @@ class SourcepointClient(
         legIntCategories: List<String>
     ): GDPRConsent =
         http.delete(URLBuilder(baseWrapperUrl).apply {
-            path("consent", "tcfv2", "consent", "v3", "custom")
-            appendPathSegments(propertyId.toString())
-            withParams(mapOf("consentUUID" to consentUUID))
+            path("consent", "tcfv2", "consent", "v3", "custom", propertyId.toString())
+            withParams(DeleteCustomConsentRequest(consentUUID))
         }.build()) {
             contentType(ContentType.Application.Json)
             setBody(

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/DeleteCustomConsentRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/DeleteCustomConsentRequest.kt
@@ -1,0 +1,6 @@
+package com.sourcepoint.mobile_core.network.requests
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeleteCustomConsentRequest(val consentUUID: String): DefaultRequest()

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -73,7 +73,6 @@ class CoordinatorTest {
     private val spClient = SourcepointClient(
         accountId = accountId,
         propertyId = propertyId,
-        propertyName = propertyName,
         httpEngine = PlatformHttpClient.create().engine
     )
     private val saveAndExitActionUsnat = SPAction.init(

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/network/SourcepointClientTest.kt
@@ -48,7 +48,6 @@ class SourcepointClientTest {
     private val api = SourcepointClient(
         accountId = accountId,
         propertyId = propertyId,
-        propertyName = propertyName,
         httpEngine = PlatformHttpClient.create().engine
     )
 
@@ -222,7 +221,7 @@ class SourcepointClientTest {
         val mockEngine = mock(delayInSeconds = 2)
 
         assertFailsWith<SPClientTimeout> {
-            SourcepointClient(accountId, propertyId, propertyName, requestTimeoutInSeconds = 1, httpEngine = mockEngine)
+            SourcepointClient(accountId, propertyId, requestTimeoutInSeconds = 1, httpEngine = mockEngine)
                 .getMetaData(campaigns = MetaDataRequest.Campaigns())
         }
     }
@@ -232,7 +231,7 @@ class SourcepointClientTest {
         val mockEngine = mock(status = HttpStatusCode.GatewayTimeout.value)
 
         assertFailsWith<SPNetworkError> {
-            SourcepointClient(accountId, propertyId, propertyName, httpEngine = mockEngine)
+            SourcepointClient(accountId, propertyId, httpEngine = mockEngine)
                 .getMetaData(campaigns = MetaDataRequest.Campaigns())
         }
 
@@ -245,7 +244,7 @@ class SourcepointClientTest {
         val mockEngine = mock(response = """{"gdpr":{}}""")
 
         assertFailsWith<SPUnableToParseBodyError> {
-            SourcepointClient(accountId, propertyId, propertyName, httpEngine = mockEngine)
+            SourcepointClient(accountId, propertyId, httpEngine = mockEngine)
                 .getMetaData(campaigns = MetaDataRequest.Campaigns())
         }
 


### PR DESCRIPTION
* [add default query params to deleteCustomConsent request](https://github.com/SourcePointUSA/mobile-core/commit/2c781fcc37a1335ead636f7a9310c236e8f89ef2)
* [fix ErrorMetricsRequest param names](https://github.com/SourcePointUSA/mobile-core/commit/24d01a5670e04b4837452ecfc7f32d5a71d1e23f)
* [remove (unneeded) propertyName from SPClient](https://github.com/SourcePointUSA/mobile-core/commit/a1bfbf6cc59d9b0a4fa8b5e116b0083bb57366cc)