### PR TITLE
Implement coordinator constructor with nullable state

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -124,6 +124,21 @@ class Coordinator(
         repository = Repository()
     )
 
+    @Suppress("Unused")
+    constructor(
+        accountId: Int,
+        propertyId: Int,
+        propertyName: SPPropertyName,
+        campaigns: SPCampaigns,
+        state: State? = null
+    ): this(
+        accountId = accountId,
+        propertyId = propertyId,
+        propertyName = propertyName,
+        campaigns = campaigns,
+        state = state ?: Repository().state ?: State(accountId = accountId, propertyId = propertyId)
+    )
+
     init {
         resetStateIfPropertyDetailsChanged()
         persistState()

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -35,6 +35,7 @@ import com.sourcepoint.mobile_core.network.requests.ConsentStatusRequest
 import com.sourcepoint.mobile_core.network.requests.MetaDataRequest
 import com.sourcepoint.mobile_core.network.responses.ConsentStatusResponse
 import com.sourcepoint.mobile_core.network.responses.MetaDataResponse
+import com.sourcepoint.mobile_core.network.responses.PvDataResponse
 import com.sourcepoint.mobile_core.storage.Repository
 import com.sourcepoint.mobile_core.utils.now
 import com.sourcepoint.mobile_core.utils.runTestWithRetries
@@ -555,5 +556,17 @@ class CoordinatorTest {
         assertFailsWith<LoadMessagesException> { getCoordinator(accountId = -1).loadMessages() }
         assertFailsWith<LoadMessagesException> { getCoordinator(propertyId = -1).loadMessages() }
         assertFailsWith<LoadMessagesException> { getCoordinator(propertyName = "foo").loadMessages() }
+    }
+
+    // TODO: add tests for the pvData payload in different circumstances (1st call vs subsequent calls)
+    @Test
+    fun pvDataIsCalledOnLoadMessage() = runTestWithRetries {
+        var pvDataCalled = false
+        val coordinator = getCoordinator(spClient = SPClientMock(postPvData = {
+            pvDataCalled = true
+            PvDataResponse()
+        }))
+        coordinator.loadMessages()
+        assertTrue(pvDataCalled)
     }
 }


### PR DESCRIPTION
* this constructor helps the Android implementation when transitioning legacy state to new state
* unrelated change, add a test to make sure `pvData` is called on `loadMessage`