### PR TITLE
DIA-5850 Additional parameters for global-cmp campaign requests

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -787,6 +787,7 @@ class Coordinator(
     private suspend fun postChoiceUSNat(action: SPAction) = spClient.postChoiceUSNatAction(
         actionType = action.type,
         request = USNatChoiceRequest(
+            accountId = accountId,
             authId = authId,
             uuid = state.usNat.consents.uuid,
             messageId = action.messageId,
@@ -805,6 +806,7 @@ class Coordinator(
     private suspend fun postChoiceGlobalCmp(action: SPAction) = spClient.postChoiceGlobalCmpAction(
         actionType = action.type,
         request = GlobalCmpChoiceRequest(
+            accountId = accountId,
             authId = authId,
             uuid = state.globalcmp.consents.uuid,
             messageId = action.messageId,

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -437,8 +437,14 @@ class Coordinator(
             when (it.type) {
                 Gdpr -> state.gdpr = state.gdpr.copy(consents = it.toConsent(default = state.gdpr.consents) as GDPRConsent)
                 Ccpa -> state.ccpa = state.ccpa.copy(consents = it.toConsent(default = state.ccpa.consents) as CCPAConsent)
-                UsNat -> state.usNat = state.usNat.copy(consents = it.toConsent(default = state.usNat.consents) as USNatConsent)
-                GlobalCmp -> state.globalcmp = state.globalcmp.copy(consents = it.toConsent(default = state.globalcmp.consents) as GlobalCmpConsent)
+                UsNat -> state.usNat = state.usNat.copy(
+                    consents = it.toConsent(default = state.usNat.consents) as USNatConsent,
+                    metaData = state.usNat.metaData.copy(messagePartitionUUID = it.messageMetaData?.messagePartitionUUID)
+                )
+                GlobalCmp -> state.globalcmp = state.globalcmp.copy(
+                    consents = it.toConsent(default = state.globalcmp.consents) as GlobalCmpConsent,
+                    metaData = state.globalcmp.metaData.copy(messagePartitionUUID = it.messageMetaData?.messagePartitionUUID)
+                )
                 IOS14 -> {
                     state.ios14 = state.ios14.copy(
                         messageId = it.messageMetaData?.messageId,
@@ -799,7 +805,8 @@ class Coordinator(
             sampleRate = state.usNat.metaData.sampleRate,
             idfaStatus = idfaStatus,
             granularStatus = state.usNat.consents.consentStatus.granularStatus,
-            includeData = includeData
+            includeData = includeData,
+            prtnUUID = state.globalcmp.metaData.messagePartitionUUID
         )
     )
 
@@ -817,7 +824,8 @@ class Coordinator(
             propertyId = propertyId,
             sampleRate = state.globalcmp.metaData.sampleRate,
             granularStatus = state.globalcmp.consents.consentStatus.granularStatus,
-            includeData = includeData
+            includeData = includeData,
+            prtnUUID = state.globalcmp.metaData.messagePartitionUUID
         )
     )
 

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/State.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/models/consents/State.kt
@@ -98,7 +98,8 @@ data class State (
             override var wasSampled: Boolean? = null,
             override var wasSampledAt: Float? = null,
             val vendorListId: String? = null,
-            val applicableSections: List<Int> = emptyList()
+            val applicableSections: List<Int> = emptyList(),
+            val messagePartitionUUID : String? = null
         ): SPSampleable
 
         fun resetStateIfVendorListChanges(newVendorListId: String): USNatState =
@@ -124,6 +125,7 @@ data class State (
             val vendorListId: String? = null,
             val applicableSections: List<String> = emptyList(),
             val legislation: String? = null,
+            val messagePartitionUUID : String? = null
         ): SPSampleable
 
         fun resetStateIfVendorListChanges(newVendorListId: String): GlobalCmpState =

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/GlobalCmpChoiceRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/GlobalCmpChoiceRequest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.JsonObject
 
 @Serializable
 class GlobalCmpChoiceRequest(
+    val accountId: Int? = null,
     val authId: String? = null,
     val uuid: String? = null,
     val messageId: String? = null,

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/GlobalCmpChoiceRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/GlobalCmpChoiceRequest.kt
@@ -18,5 +18,6 @@ class GlobalCmpChoiceRequest(
     val propertyId: Int,
     val sampleRate: Float,
     val granularStatus: ConsentStatus.ConsentStatusGranularStatus? = null,
-    val includeData: IncludeData = IncludeData()
+    val includeData: IncludeData = IncludeData(),
+    val prtnUUID: String? = null
 )

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/USNatChoiceRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/USNatChoiceRequest.kt
@@ -19,5 +19,6 @@ data class USNatChoiceRequest (
     val sampleRate: Float,
     val idfaStatus: SPIDFAStatus? = SPIDFAStatus.current(),
     val granularStatus: ConsentStatus.ConsentStatusGranularStatus? = null,
-    val includeData: IncludeData = IncludeData()
+    val includeData: IncludeData = IncludeData(),
+    val prtnUUID: String? = null
 )

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/USNatChoiceRequest.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/USNatChoiceRequest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.JsonObject
 
 @Serializable
 data class USNatChoiceRequest (
+    val accountId: Int? = null,
     val authId: String? = null,
     val uuid: String? = null,
     val messageId: String? = null,


### PR DESCRIPTION
Feature request:
[DIA-5850](https://sourcepoint.atlassian.net/browse/DIA-5850) For global-cmp actions from mobile SDK (Android so far), missing accountId in the post request for action choices

