### PR TITLE
DIA-6098 fix `authId` not being passed to POST choice

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,12 +2,12 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    kotlin("multiplatform") version "2.2.0"
-    kotlin("native.cocoapods") version "2.2.0"
-    kotlin("plugin.serialization") version "2.2.0"
+    kotlin("multiplatform") version "2.1.21"
+    kotlin("native.cocoapods") version "2.1.21"
+    kotlin("plugin.serialization") version "2.1.21"
     id("com.github.ben-manes.versions") version "0.52.0"
     id("com.android.library") version "8.11.1"
-    id("com.github.gmazzo.buildconfig") version "5.6.7"
+    id("com.github.gmazzo.buildconfig") version "5.6.8"
     id("com.vanniktech.maven.publish") version "0.34.0"
     id("signing")
 }

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -68,8 +68,8 @@ class Coordinator(
         propertyId = propertyId,
         requestTimeoutInSeconds = timeoutInSeconds
     ),
-    private var authId: String? = null,
     internal var state: State = repository.state ?: State(accountId = accountId, propertyId = propertyId),
+    private var authId: String? = state.authId,
 ): ICoordinator {
     private val idfaStatus: SPIDFAStatus? get() = getIDFAStatus()
     // TODO: implement using expect/actual

--- a/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
+++ b/core/src/commonTest/kotlin/com/sourcepoint/mobile_core/CoordinatorTest.kt
@@ -617,7 +617,7 @@ class CoordinatorTest {
     fun throwsLoadMessagesExceptionIfTheConfigIsWrong() = runTestWithRetries {
         assertFailsWith<LoadMessagesException> { getCoordinator(accountId = -1).loadMessages() }
         assertFailsWith<LoadMessagesException> { getCoordinator(propertyId = -1).loadMessages() }
-        assertFailsWith<LoadMessagesException> { getCoordinator(propertyName = "foo").loadMessages() }
+        assertFailsWith<LoadMessagesException> { getCoordinator(propertyName = "foo-mobile-core-test").loadMessages() }
     }
 
     // TODO: add tests for the pvData payload in different circumstances (1st call vs subsequent calls)

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,3 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.binary.objcExportSuspendFunctionLaunchThreadRestriction=none
 #kotlin.native.cacheKind.iosX64=none
 #kotlin.native.cacheKind.iosArm64=none
-
-kotlin.mpp.androidGradlePluginCompatibility.nowarn=true


### PR DESCRIPTION
If `loadMessages` is not called with an `authId`, the `Coordinator` class has its `authId` property set to `null`, even if there's an `authId` stored in the local storage.

This PR initializes `authId` based on `State` if none is passed to `Coordinator`'s constructor.

This PR also rolls back kotlin version to 2.1.21 from 2.2.0 for higher compatibility with clients of the Android SDK. 