### PR TITLE
[DIA-6102] add `supportLegacyUSPString` logic

### DIFF
--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/Coordinator.kt
@@ -206,6 +206,7 @@ class Coordinator(
         language: SPMessageLanguage
     ): List<MessageToDisplay> {
         this.authId = authId
+        this.includeData.gppData.uspString = campaigns.usnat?.supportLegacyUSPString
         resetStateIfAuthIdChanged()
         var messages: List<MessageToDisplay> = emptyList()
         try {

--- a/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/IncludeData.kt
+++ b/core/src/commonMain/kotlin/com/sourcepoint/mobile_core/network/requests/IncludeData.kt
@@ -24,7 +24,7 @@ data class IncludeData(
         val MspaCoveredTransaction: MspaBinaryFlag? = null,
         val MspaOptOutOptionMode: MspaTernaryFlag? = null,
         val MspaServiceProviderMode: MspaTernaryFlag? = null,
-        val uspString: Boolean? = true
+        var uspString: Boolean? = true
     ) {
         override fun toString() = json.encodeToString(this)
     }


### PR DESCRIPTION
[DIA-6102](https://sourcepoint.atlassian.net/browse/DIA-6102)
[iOS] SDKs Are Setting US Privacy String Even When supportLegacyUSPString: true Is Not Used

>Expected result: is that if the supportLegacyUSPString parameter is not used, the US Privacy UserDefaults will not be set. Only the GPP values will be set.